### PR TITLE
Use full patch version in GitHub Actions digest comments

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,8 +12,8 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .node-version
           cache: npm


### PR DESCRIPTION
## What

`.github/workflows/validate.yml` でピン留めしている GitHub Actions のバージョンコメントを、major 表記から patch まで含む完全な semver 表記に変更しました。SHA 自体は変更していません。

```diff
- uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
- uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+ uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+ uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
```

## Why

Renovate の github-actions manager は `uses: owner/repo@<sha>` の末尾コメントを currentValue として読みます。`# v6` のままだと major 表記が currentValue となり、setup-node の minor / patch 更新が検知されない状態でした。実際 setup-node はピン留め SHA が v6.4.0 で、現時点の最新は v6.5.0 です。

patch まで表記することで、`pin-github-actions` preset (`helpers:pinGitHubActionDigests`) と併せて更新が正しく追従します。

## Verification

GitHub API で SHA ↔ tag を双方向に検証済みです。

| action | pinned SHA | comment | tag が指す commit | 判定 |
|---|---|---|---|---|
| actions/checkout | `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` | `v7.0.0` | 同一 | ✅ |
| actions/setup-node | `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` | `v6.4.0` | 同一 | ✅ |

- 両 SHA とも対象リポジトリに実在する commit（checkout: 2026-06-17 / setup-node: 2026-04-20）
- どちらも lightweight tag のため annotated tag の二段解決は不要
- 当該 commit を指す全タグ: checkout → `v7.0.0`, `v7` / setup-node → `v6.4.0` のみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)